### PR TITLE
[FEAT] Controller 단에서 발생하는 예외를 전역적으로 처리하기 위한 기능 구현

### DIFF
--- a/src/main/java/org/sopt/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,34 @@
 package org.sopt.common.exception;
 
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
 public class GlobalExceptionHandler {
+    private static final String LOG_FORMAT = "%s";
+    private static final String SERVER_ERROR_MESSAGE = "서버 오류가 발생하였습니다.";
+
+
+    @ExceptionHandler(BaseCustomException.class)
+    public ResponseEntity<ExceptionResponse> handleBaseException(BaseCustomException e) {
+        ExceptionType exceptionType = e.getExceptionType();
+        log.info(String.format(LOG_FORMAT, e.getMessage()), e);
+        return ResponseEntity.status(exceptionType.httpStatus())
+                .body(ExceptionResponse.of(exceptionType.name(), exceptionType.message()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(Exception e) {
+        HttpStatus httpStatus = INTERNAL_SERVER_ERROR;
+        log.error(String.format(LOG_FORMAT, e.getMessage()), e);
+        return ResponseEntity.status(httpStatus)
+                .body(ExceptionResponse.of(httpStatus.name(), SERVER_ERROR_MESSAGE));
+    }
 
 }


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #5 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
예외를 전역적으로 처리하기 위해 RestControllerAdvice를 구현함
- BaseCustomException가 발생했을 때는 발생한 예외의 이름과 메시지를 리턴하고,
- 그 외 예외가 발생했을 때는 서버에 오류가 발생했다는 메시지를 리턴함

