### PR TITLE
[CHORE] 전일 종가 데이터 변수 명 변경

### DIFF
--- a/src/main/java/org/sopt/domain/Stock.java
+++ b/src/main/java/org/sopt/domain/Stock.java
@@ -4,7 +4,6 @@ import static jakarta.persistence.EnumType.STRING;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -40,7 +39,7 @@ public class Stock {
 
     private String fluctuationPrice;
 
-    private String previousDayIncrease;
+    private String previousDayClosingPrice;
 
     private String marketCapitalization;
 


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #14 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
전일 종가 정보의 컬럼/변수 명이 previous_day_increase로 되어있어서 이를 previous_day_closing_price로 변경했다