### PR TITLE
[FEAT] 전체 시장 지수 조회 api 구현 

### DIFF
--- a/src/main/java/org/sopt/api/stockIndex/controller/StockIndexController.java
+++ b/src/main/java/org/sopt/api/stockIndex/controller/StockIndexController.java
@@ -1,11 +1,7 @@
 package org.sopt.api.stockIndex.controller;
 
-import static java.util.Collections.emptyList;
-
 import jakarta.annotation.Nullable;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.api.stockIndex.controller.dto.response.GetStockIndexResponseDto;
 import org.sopt.api.stockIndex.service.StockIndexService;
 import org.sopt.domain.Continent;
 import org.springframework.http.ResponseEntity;
@@ -23,12 +19,11 @@ public class StockIndexController {
 
 
     @GetMapping
-    public ResponseEntity<List<GetStockIndexResponseDto>> getStockIndexList(
+    public ResponseEntity<Object> getStockIndexList(
             @Nullable @RequestParam String continent) {
 
         if (continent == null) {
-            // TODO: 전체 시장 지수 조회
-            return ResponseEntity.ok(emptyList());
+            return ResponseEntity.ok(stockIndexService.getAllStockIndexAndGroupByContinent());
         }
 
         return ResponseEntity.ok(stockIndexService.getStockIndexByContinent(Continent.find(continent)));

--- a/src/main/java/org/sopt/api/stockIndex/service/StockIndexService.java
+++ b/src/main/java/org/sopt/api/stockIndex/service/StockIndexService.java
@@ -1,8 +1,12 @@
 package org.sopt.api.stockIndex.service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.sopt.api.stockIndex.controller.dto.response.GetStockIndexResponseDto;
+import org.sopt.common.util.StockIndexGrouper;
 import org.sopt.domain.Continent;
 import org.sopt.domain.StockIndex;
 import org.sopt.domain.repository.StockRepository;
@@ -20,4 +24,25 @@ public class StockIndexService {
 
         return stockIndexList.stream().map(GetStockIndexResponseDto::of).toList();
     }
+
+    public Map<String, List<GetStockIndexResponseDto>> getAllStockIndexAndGroupByContinent() {
+        List<StockIndex> stockIndexList = stockRepository.findAll();
+        StockIndexGrouper stockIndexGrouper = new StockIndexGrouper(stockIndexList);
+
+        Map<Continent, List<StockIndex>> stockIndexMapByContinent = stockIndexGrouper.groupByContinent();
+
+        Map<String, List<GetStockIndexResponseDto>> result = new HashMap<>();
+        stockIndexMapByContinent.forEach((key, valueList) ->
+                {
+                    for (StockIndex stockIndex : valueList) {
+                        result.computeIfAbsent(key.getKorean(), k -> new ArrayList<>())
+                                .add(GetStockIndexResponseDto.of(stockIndex));
+                    }
+
+                }
+        );
+
+        return result;
+    }
+
 }

--- a/src/main/java/org/sopt/api/stockIndex/service/StockIndexService.java
+++ b/src/main/java/org/sopt/api/stockIndex/service/StockIndexService.java
@@ -9,7 +9,7 @@ import org.sopt.api.stockIndex.controller.dto.response.GetStockIndexResponseDto;
 import org.sopt.common.util.StockIndexGrouper;
 import org.sopt.domain.Continent;
 import org.sopt.domain.StockIndex;
-import org.sopt.domain.repository.StockRepository;
+import org.sopt.domain.repository.StockIndexRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,16 +17,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Service
 public class StockIndexService {
-    private final StockRepository stockRepository;
+    private final StockIndexRepository stockIndexRepository;
 
     public List<GetStockIndexResponseDto> getStockIndexByContinent(Continent continent) {
-        List<StockIndex> stockIndexList = stockRepository.findAllByContinent(continent);
+        List<StockIndex> stockIndexList = stockIndexRepository.findAllByContinent(continent);
 
         return stockIndexList.stream().map(GetStockIndexResponseDto::of).toList();
     }
 
     public Map<String, List<GetStockIndexResponseDto>> getAllStockIndexAndGroupByContinent() {
-        List<StockIndex> stockIndexList = stockRepository.findAll();
+        List<StockIndex> stockIndexList = stockIndexRepository.findAll();
         StockIndexGrouper stockIndexGrouper = new StockIndexGrouper(stockIndexList);
 
         Map<Continent, List<StockIndex>> stockIndexMapByContinent = stockIndexGrouper.groupByContinent();

--- a/src/main/java/org/sopt/common/util/StockIndexGrouper.java
+++ b/src/main/java/org/sopt/common/util/StockIndexGrouper.java
@@ -1,0 +1,29 @@
+package org.sopt.common.util;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.sopt.domain.Continent;
+import org.sopt.domain.StockIndex;
+
+public class StockIndexGrouper {
+    private final List<StockIndex> stockIndexList;
+
+    public StockIndexGrouper(List<StockIndex> stockIndexList) {
+        this.stockIndexList = stockIndexList;
+    }
+
+    public Map<Continent, List<StockIndex>> groupByContinent() {
+
+        EnumMap<Continent, List<StockIndex>> result = new EnumMap<>(Continent.class);
+
+        for (StockIndex stockIndex : stockIndexList) {
+            Continent continent = stockIndex.getContinent();
+            result.computeIfAbsent(continent, k -> new ArrayList<>()).add(stockIndex);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/org/sopt/domain/Continent.java
+++ b/src/main/java/org/sopt/domain/Continent.java
@@ -3,11 +3,15 @@ package org.sopt.domain;
 import static org.sopt.api.stockIndex.exception.StockIndexExceptionType.NOT_FOUND_CONTINENT;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.sopt.api.stockIndex.exception.StockIndexException;
 
+@RequiredArgsConstructor
 @Getter
 public enum Continent {
-    AMERICA, EUROPE, MIDDLE_EAST, AFRICA, ASIA;
+    AMERICA("미국"), EUROPE("유럽"), MIDDLE_EAST("중동"), AFRICA("아프리카"), ASIA("아시아");
+
+    private final String korean;
 
     public static Continent find(String continent) {
         for (Continent c : values()) {

--- a/src/main/java/org/sopt/domain/repository/StockIndexRepository.java
+++ b/src/main/java/org/sopt/domain/repository/StockIndexRepository.java
@@ -5,7 +5,7 @@ import org.sopt.domain.Continent;
 import org.sopt.domain.StockIndex;
 import org.springframework.data.repository.Repository;
 
-public interface StockRepository extends Repository<StockIndex, Long> {
+public interface StockIndexRepository extends Repository<StockIndex, Long> {
 
     List<StockIndex> findAll();
 

--- a/src/main/java/org/sopt/domain/repository/StockRepository.java
+++ b/src/main/java/org/sopt/domain/repository/StockRepository.java
@@ -6,5 +6,8 @@ import org.sopt.domain.StockIndex;
 import org.springframework.data.repository.Repository;
 
 public interface StockRepository extends Repository<StockIndex, Long> {
+
+    List<StockIndex> findAll();
+
     List<StockIndex> findAllByContinent(Continent continent);
 }


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #16 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
### StockIndexRepository
- 전체 StockIndex를 조회하는 findAll 메서드 정의
### StockIndexContoller
- getStockIndexList 응답 값을 Object로 변경함.
    - 이유: RequestParam 여부에 따라 응답 타입이 달라서.
### StockIndexService
- getAllStockIndexAndGroupByContinent 메서드
    - Continent가 같은 것끼리 StockIndex 묶어서 Map 리턴
### StockIndexGrouper
- StockIndex의 배열을 Map<Continent, List<StockIndex>>로 묶어주는 역할을 하는 객체
### Continent
- Continent의 한글을 응답 값으로 리턴해야하는 경우를 위해 한글도 저장

### 테스트 결과
- 결과
    <img width="1014" alt="image" src="https://github.com/DOSOPT-CDS-WEB-TEAM2/SERVER/assets/78674565/55267078-0d79-4d1f-b245-8b841312737a">


## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
그룹핑 하는 로직이 많아서 조금 복잡해 보이는 거 같기도하네요 .. 의견 부탁드립니다!!!
또, Controller 메서드의 응답 값이 RequestParam 존재 여부에 따라서 달라서 Object로 리턴한 부분도 체크 부탁드립니다ㅏ