### PR TITLE
[FEAT] 특정 주식과 관련된 주식들 조회하는 API 구현

### DIFF
--- a/src/main/java/org/sopt/api/stock/controller/StockController.java
+++ b/src/main/java/org/sopt/api/stock/controller/StockController.java
@@ -1,13 +1,20 @@
 package org.sopt.api.stock.controller;
 
+import static org.sopt.api.stock.exception.StockExceptionType.NOT_FOUND_RELATED_STOCK;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.api.stock.controller.dto.response.GetRelatedStockResponseDto;
 import org.sopt.api.stock.controller.dto.response.GetStockResponseDto;
+import org.sopt.api.stock.exception.StockException;
 import org.sopt.api.stock.service.StockService;
+import org.sopt.domain.Type;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,5 +27,12 @@ public class StockController {
     @GetMapping("/{stockCode}")
     public ResponseEntity<GetStockResponseDto> getStock(@PathVariable String stockCode){
         return ResponseEntity.ok(stockService.getStock(stockCode));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<GetRelatedStockResponseDto>> getRelatedStockList(
+            @RequestParam String type){
+
+        return ResponseEntity.ok(stockService.getRelatedStockList(Type.find(type)));
     }
 }

--- a/src/main/java/org/sopt/api/stock/controller/StockController.java
+++ b/src/main/java/org/sopt/api/stock/controller/StockController.java
@@ -1,13 +1,9 @@
 package org.sopt.api.stock.controller;
 
-import static org.sopt.api.stock.exception.StockExceptionType.NOT_FOUND_RELATED_STOCK;
-
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.sopt.api.stock.controller.dto.response.GetRelatedStockResponseDto;
 import org.sopt.api.stock.controller.dto.response.GetStockResponseDto;
-import org.sopt.api.stock.exception.StockException;
 import org.sopt.api.stock.service.StockService;
 import org.sopt.domain.Type;
 import org.springframework.http.ResponseEntity;
@@ -25,13 +21,13 @@ public class StockController {
     private final StockService stockService;
 
     @GetMapping("/{stockCode}")
-    public ResponseEntity<GetStockResponseDto> getStock(@PathVariable String stockCode){
+    public ResponseEntity<GetStockResponseDto> getStock(@PathVariable String stockCode) {
         return ResponseEntity.ok(stockService.getStock(stockCode));
     }
 
     @GetMapping
     public ResponseEntity<List<GetRelatedStockResponseDto>> getRelatedStockList(
-            @RequestParam String type){
+            @RequestParam String type) {
 
         return ResponseEntity.ok(stockService.getRelatedStockList(Type.find(type)));
     }

--- a/src/main/java/org/sopt/api/stock/controller/dto/response/GetRelatedStockResponseDto.java
+++ b/src/main/java/org/sopt/api/stock/controller/dto/response/GetRelatedStockResponseDto.java
@@ -1,0 +1,21 @@
+package org.sopt.api.stock.controller.dto.response;
+
+import lombok.Builder;
+import org.sopt.domain.Stock;
+
+@Builder
+public record GetRelatedStockResponseDto(
+        String code,
+        String name,
+        String currentPrice,
+        float fluctuationRate
+) {
+    public static GetRelatedStockResponseDto of(Stock stock) {
+        return GetRelatedStockResponseDto.builder()
+                .code(stock.getCode())
+                .name(stock.getName())
+                .currentPrice(stock.getCurrentPrice())
+                .fluctuationRate(stock.getFluctuationRate())
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/api/stock/controller/dto/response/GetRelatedStockResponseDto.java
+++ b/src/main/java/org/sopt/api/stock/controller/dto/response/GetRelatedStockResponseDto.java
@@ -1,9 +1,10 @@
 package org.sopt.api.stock.controller.dto.response;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import org.sopt.domain.Stock;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public record GetRelatedStockResponseDto(
         String code,
         String name,

--- a/src/main/java/org/sopt/api/stock/controller/dto/response/GetStockResponseDto.java
+++ b/src/main/java/org/sopt/api/stock/controller/dto/response/GetStockResponseDto.java
@@ -8,12 +8,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import org.sopt.domain.Portfolio;
 import org.sopt.domain.Stock;
 import org.sopt.domain.Type;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public record GetStockResponseDto(
         String code,
         String name,

--- a/src/main/java/org/sopt/api/stock/exception/StockExceptionType.java
+++ b/src/main/java/org/sopt/api/stock/exception/StockExceptionType.java
@@ -6,7 +6,9 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum StockExceptionType implements ExceptionType {
-    NOT_FOUND_STOCK(HttpStatus.NOT_FOUND, "존재하지 않는 주식입니다.");
+    NOT_FOUND_STOCK(HttpStatus.NOT_FOUND, "존재하지 않는 주식입니다."),
+    NOT_FOUND_RELATED_STOCK(HttpStatus.NOT_FOUND, "관련된 주식은 존재하지 않습니다.");
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/sopt/api/stock/service/StockService.java
+++ b/src/main/java/org/sopt/api/stock/service/StockService.java
@@ -1,8 +1,11 @@
 package org.sopt.api.stock.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.api.stock.controller.dto.response.GetRelatedStockResponseDto;
 import org.sopt.api.stock.controller.dto.response.GetStockResponseDto;
 import org.sopt.domain.Stock;
+import org.sopt.domain.Type;
 import org.sopt.domain.repository.StockRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,5 +19,11 @@ public class StockService {
     public GetStockResponseDto getStock(String code) {
         Stock stock = stockRepository.findByCodeOrThrow(code);
         return GetStockResponseDto.of(stock);
+    }
+
+    public List<GetRelatedStockResponseDto> getRelatedStockList(Type type){
+        List<Stock> relatedStockList = stockRepository.findAllByType(type);
+        return relatedStockList.stream().
+                map(stock->GetRelatedStockResponseDto.of(stock)).toList();
     }
 }

--- a/src/main/java/org/sopt/api/stock/service/StockService.java
+++ b/src/main/java/org/sopt/api/stock/service/StockService.java
@@ -21,9 +21,9 @@ public class StockService {
         return GetStockResponseDto.of(stock);
     }
 
-    public List<GetRelatedStockResponseDto> getRelatedStockList(Type type){
+    public List<GetRelatedStockResponseDto> getRelatedStockList(Type type) {
         List<Stock> relatedStockList = stockRepository.findAllByType(type);
         return relatedStockList.stream().
-                map(stock->GetRelatedStockResponseDto.of(stock)).toList();
+                map(stock -> GetRelatedStockResponseDto.of(stock)).toList();
     }
 }

--- a/src/main/java/org/sopt/domain/Type.java
+++ b/src/main/java/org/sopt/domain/Type.java
@@ -1,8 +1,23 @@
 package org.sopt.domain;
 
+import static org.sopt.api.stock.exception.StockExceptionType.NOT_FOUND_RELATED_STOCK;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.api.stock.exception.StockException;
 
+@RequiredArgsConstructor
 @Getter
 public enum Type {
-    CHEMISTRY, ETC
+    CHEMISTRY, ETC;
+
+    //private final String korean;
+
+    public static Type find(String type) {
+        for (Type t : values()) {
+            if (t.name().equalsIgnoreCase(type)) {
+                return t;
+            }
+        }
+        throw new StockException(NOT_FOUND_RELATED_STOCK);
+    }
 }

--- a/src/main/java/org/sopt/domain/repository/StockRepository.java
+++ b/src/main/java/org/sopt/domain/repository/StockRepository.java
@@ -2,11 +2,14 @@ package org.sopt.domain.repository;
 
 import static org.sopt.api.stock.exception.StockExceptionType.NOT_FOUND_STOCK;
 
+import java.util.List;
 import org.sopt.api.stock.exception.StockException;
 import org.sopt.domain.Stock;
+import org.sopt.domain.Type;
 import org.springframework.data.repository.Repository;
 
 public interface StockRepository extends Repository<Stock, String> {
+    List<Stock> findAllByType(Type type);
     Stock findByCode(String code);
 
     default Stock findByCodeOrThrow(String code) {


### PR DESCRIPTION
## 📌 관련 이슈
#17 

## ✨ 어떤 이유로 변경된 내용인지
### StockController
- `RequestParam`(주식 타입)을 받는 getRelatedStockList() 메서드 추가

### GetRelatedStockResponseDto
- 관련된 주식 정보를 반환하는 DTO

### StockException
- 잘못된 주식 타입으로 요청할 경우 예외 처리

### Type
- 해당 타입에 맞는 `enum` 반환하는 `find()`함수 추가

## 테스트
- 결과
    <img width="1028" alt="image" src="https://github.com/DOSOPT-CDS-WEB-TEAM2/SERVER/assets/78674565/75189d51-ea31-4ab7-bc10-f2a879434a67">

    <img width="620" alt="image" src="https://github.com/DOSOPT-CDS-WEB-TEAM2/SERVER/assets/78674565/df193987-f8a9-4c4d-9b0c-2d8209ca9c99">



## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 2가지 방법 중에 고민하다가 결국 분리해서 구현했습니다!
- `@JsonInclude(Include.NON_NULL)`도 고민했지만, 현재 구현방식이 나름 확장성과 의존성 측면에서 더 좋다는 판단을 해봤습니다..!