### PR TITLE
[FIX] CORS 설정이 적용되지 않는 것을 수정한다.

### DIFF
--- a/src/main/java/org/sopt/config/WebConfig.java
+++ b/src/main/java/org/sopt/config/WebConfig.java
@@ -1,13 +1,18 @@
 package org.sopt.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
-        registry.addMapping("/**").allowedOrigins("*");
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods(HttpMethod.GET.name())
+                .maxAge(3000);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #29 

## ✨ 어떤 이유로 변경된 내용인지
-  기존의 cors 설정이 적용되지 않았음
    - 이유: allowedOrigins는 정확한 주소를 입력하는 것이기 때문에 패턴인 "*"입력으로는 안됨
- 변경: allowedOriginPatterns으로 패턴을 입력받도록 수정
